### PR TITLE
Rewrite of Parent object: clean up description +unified style with other typed objects.

### DIFF
--- a/EXAMPLE.yaml
+++ b/EXAMPLE.yaml
@@ -48,7 +48,8 @@ components:
     id: web-service
     description: Runs our web application
     parent:
-      trustZone: private
+        id: private
+        type: trustZone
     type: web-service
     tags:
       - tomcat
@@ -78,7 +79,8 @@ components:
     id: customer-database
     description: Postgres database
     parent:
-      trustZone: private
+        id: private
+        type: trustZone
     type: database
     tags:
       - postgres
@@ -97,7 +99,8 @@ components:
     description: Managages customer database
     type: code-class
     parent:
-      trustZone: private
+        id: private
+        type: trustZone
     representations:
       - representation: application-code
         id: data abse class
@@ -155,7 +158,8 @@ trustZones:
     risk:
       trustRating: 100
     parent:
-      trustZone: internet
+        id: private
+        type: trustZone
     representations:
       - representation: architecture-diagram
         id: private-box-shape

--- a/README.md
+++ b/README.md
@@ -879,9 +879,12 @@ Components are the different pieces of software / hardware that make our project
 <tr>
 <td>parent</td>
 <td><a href="#parent-object">Parent object</a></td>
-<td><b>REQUIRED</b> Element in which this component is currently enclosed. It can be either a trust zone or another 
-component. It should contain an attribute name stating the component type to avoid ambiguity.
-<br/>A component must have just <b>one parent</b>: another component or a trust zone.
+<td><b>REQUIRED</b> This object describes the parent element in which this component is currently enclosed. It contains the unique identifier and the type of the parent element.
+
+<br /> A component must have just <b>one parent</b>: another component or a trust zone.<br/>
+<br /> The type of a the parent could be component or trust zone.<br/>
+
+
 </td>
 <td></td>
 </tr>
@@ -1059,9 +1062,13 @@ Trust zones are the different areas within which components are located. They de
 <tr>
 <td>parent</td>
 <td><a href="#parent-object">Parent object</a></td>
-<td>	
-Unique identifier of the component or trust zone enclosing this trust zone. It should contain an attribute name stating the element type.<br />
-A trust zone can have <b>zero or one parent</b>: another component or a trust zone.
+
+</td>
+<td>This object describes the parent element in which this trust zone is currently enclosed. It contains the unique identifier and the type of the parent element.<br/>
+
+<br /> A trust zone can have <b>zero or one parent</b><br/>
+<br /> The type of a the parent could be component or trust zone.<br/>
+
 </td>
 <td></td>
 </tr>
@@ -1166,7 +1173,7 @@ risk:
 
 ## Parent object
 
-Element that encloses another element. It can be either a trust zone or a component. Currently, we have two supported types of parents:
+A refernece to the enclosing element. It can be either a trust zone or a component. Currently, we have two supported types of parents:
 
 - trustZone
 - component
@@ -1181,25 +1188,25 @@ Element that encloses another element. It can be either a trust zone or a compon
 
 <tr></tr>
 <tr>
-<td>trustZone</td>
+<td>id</td>
 <td>string</td>
 <td>	
-Id of the element in which this component is currently enclosed. It can be either a trust zone or another component. It should contain an attribute name stating the component type to avoid ambiguity</td>
+Id of the element in which this component is currently enclosed.</td>
 <td>
 
-    trustZone: private
+    id: private
 
 </td>
 </tr>
 
 <tr></tr>
 <tr>
-<td>component</td>
+<td>type</td>
 <td>string</td>
-<td>Id of the element in which this component is currently enclosed. It can be either a trust zone or another component. It should contain an attribute name stating the component type to avoid ambiguity</td>
+<td>Type of the element in which this component is currently enclosed. It can be either a trust zone or another component.</td>
 <td>
 
-    component: web-server
+    type: trustZone
 
 </td>
 </tr>
@@ -1210,12 +1217,14 @@ Id of the element in which this component is currently enclosed. It can be eithe
 
 ```yaml
 parent:
-  trustZone: private
+  id: private
+  type: trustZone
 ```
 
 ```yaml
 parent:
-  component: web-server
+  id: web-server
+  type: component
 ```
 
 ## Dataflows object

--- a/README.md
+++ b/README.md
@@ -938,7 +938,8 @@ components:
     type: web-service
     description: Runs our web application
     parent:
-      trustZone: private
+      id: private
+      type: trustZone
     tags:
       - tomcat
     representations:
@@ -970,7 +971,8 @@ components:
     id: customer-database
     description: Postgres database
     parent:
-      trustZone: private
+        id: private
+        type: trustZone
     type: database
     tags:
       - postgres
@@ -988,7 +990,8 @@ components:
     description: Managages customer database
     type: code-class
     parent:
-      trustZone: private
+      id: private
+      type: trustZone
     representations:
       - representation: application-code
         id: source-to-go-class
@@ -1125,7 +1128,9 @@ trustzones:
     description: Private trustzone for protected components
     risk:
       trustRating: 15
-    parent: internet
+    parent: 
+      id: internet
+      type: trustZone
     representations:
       representation: architecture-diagram
       id: private-box-shape


### PR DESCRIPTION
Dear Team, 

Please consider changing the current Parent object syntax and semantics to the proposed form in the pull request.

The current syntax captures type and id of the parent and represents it as a map entry like syntax where the value of the key entry encodes the type information. This syntax leaves the responsibility of  enforcing that a parent is indeed only has a type of trustZone or component to the domain logic after parsing the otm. (First element is deserialized to a one element map, then additionall the entry must be validated after creation - I believe a fragile way of checking for consistency. ).  

Other elements in the OTM spec however - Representation for example - chose a separate "type" and "id" entry to contain this information. Re-using the same syntax encodes the type information on the syntax level and makes typa validation during deserializtion possible. 

In Java code for example it is quite easy this way to deserialize the element directly to an implementation (either of class TrustZone or that of Component) of the abstract Parent class with a sinlge field ID - what makes perfect sense for an element what is essentially a typed reference to a concrete instance of an other element.

In case this PR is accpeted, I would recommend changing the possible types of Parent to trustZoneRef and componentRef (or similar) emphasizing the distinction between the actual parent element and the element referencing it.

Kr. Daniel