### PR TITLE
Create otm_schema.json

### DIFF
--- a/otm_schema.json
+++ b/otm_schema.json
@@ -1,0 +1,280 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://iriusrisk.com/schema/otm-0.1.0.schema.json",
+    "title": "Open Threat Model Specification",
+    "$comment" : "Open Threat Model JSON schema is published under the terms of the Apache License 2.0.",
+    "type": "object",
+    "required": ["project", "otmVersion"],
+    "properties": {
+        "project": {
+            "type": "object",
+            "required": ["name", "id"],
+            "properties": {
+                "name": {"type": "string"},
+                "id": {"type": "string"},
+                "description": {"type": "string"},
+                "owner": {"type": "string"},
+                "ownerContact": {"type": "string"},
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "attributes": {"type": "object"}
+            }
+        },
+        "representations": {
+            "type": "array",
+            "required": ["name", "id", "type"],
+            "properties": {
+                "name": {"type": "string"},
+                "id": {"type": "string"},
+                "type": {"type": "string"},
+                "description": {"type": "string"},
+                "size": {"$ref": "#/definitions/size"},
+                "repository": {
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {"type": "string"}
+                    }
+                },
+                "attributes": {"type": "object"}
+            }
+        },
+        "assets": {
+            "type": "array",
+            "required": ["name", "id", "risk"],
+            "properties": {
+                "name": {"type": "string"},
+                "id": {"type": "string"},
+                "description": {"type": "string"},
+                "risk": {
+                    "type": "object",
+                    "required": ["confidentiality", "integrity", "availability"],
+                    "properties": {
+                        "confidentiality": {"type": "number"},
+                        "integrity": {"type": "number"},
+                        "availability": {"type": "number"},
+                        "comment": {"type": "string"}
+                    }
+                },
+                "attributes": {"type": "object"}
+            }
+        },
+        "trustZones": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "name", "risk"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "type": {"type": "string"},
+                    "description": {"type": "string"},
+                    "risk": {
+                        "type": "object",
+                        "required": ["trustRating"],
+                        "properties": {
+                            "trustRating": {"type": "number"}
+                        }
+                    },
+                    "parent": {"$ref": "#/definitions/parent"},
+                    "representations": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/representationElement"}
+                    },
+                    "attributes": {"type": "object"}
+                }
+            }
+        },
+        "components": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "name", "type", "parent"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "type": {"type": "string"},
+                    "description": {"type": "string"},
+                    "parent": {"$ref": "#/definitions/parent"},
+                    "representations": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/representationElement"}
+                    },
+                    "assets": {
+                        "type": "object",
+                        "properties": {
+                            "stored": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "processed": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "threats": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/threat/"}
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "attributes": {"type": "object"}
+                }
+            }
+        },
+        "dataflows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "name", "source", "destination"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "bidirectional": {"type": "boolean"},
+                    "source": {"type": "string"},
+                    "destination": {"type": "string"},
+                    "assets": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "threats": {"$ref": "#/definitions/threat"},
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "attributes": {"type": "object"}
+                }
+            }
+        },
+        "threats": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "name", "risk"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "categories": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "cwes": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "risk": {
+                        "type": "object",
+                        "required": ["likelihood", "impact"],
+                        "properties": {
+                            "likelihood": {"type": "number"},
+                            "likelihoodComment": {"type": "string"},
+                            "impact": {"type": "number"},
+                            "impactComment": {"type": "string"}
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "attributes": {"type": "object"}
+                }
+            }
+        },
+        "mitigations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "name", "riskReduction"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "riskReduction": {"type": "number"},
+                    "attributes": {"type": "object"}
+                }
+            }
+        }
+    },
+    "definitions": {
+        "size": {
+            "type": "object",
+            "required": ["width", "height"],
+            "properties": {
+                "width": {"type": "number"},
+                "height": {"type": "number"}
+            }
+        },
+        "parent": {
+            "type": "object",
+            "oneOf": [
+                {"required": ["trustZone"]},
+                {"required":["component"]}
+            ],
+            "properties": {
+                "trustZone": {"type": "string"},
+                "component": {"type": "string"}
+            }
+        },
+        "position": {
+            "type": "object",
+            "required": ["x", "y"],
+            "properties": {
+                "x": {"type": "number"},
+                "y": {"type": "number"}
+            }
+        },
+        "representationElement": {
+            "type": "object",
+            "required": ["representation", "id"],
+            "properties": {
+                "representation": {"type": "string"},
+                "name": {"type": "string"},
+                "id": {"type": "string"},
+                "position": {"$ref": "#/definitions/position"},
+                "size": {"$ref": "#/definitions/size"},
+                "file": {"type": "string"},
+                "line": {"type": "number"},
+                "codeSnippet": {"type": "string"},
+                "attributes": {"type": "object"}
+            }
+        },
+        "threat": {
+            "type": "object",
+            "required": ["threat", "state"],
+            "properties": {
+                "threat": {"type": "string"},
+                "state": {"type": "string"},
+                "mitigations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["mitigation", "state"],
+                        "properties": {
+                            "mitigation": {"type": "string"},
+                            "state": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Given that PR https://github.com/iriusrisk/OpenThreatModel/pull/5  is over a year old and I would like the schema from https://github.com/iriusrisk/startleft/blob/main/otm/resources/schemas/otm_schema.json added here I created a separate PR. If this PR is approved I think https://github.com/iriusrisk/OpenThreatModel/pull/5 can be closed