### PR TITLE
Update otm_schema.json

### DIFF
--- a/otm_schema.json
+++ b/otm_schema.json
@@ -7,7 +7,7 @@
     "required": ["otmVersion", "project"],
     "properties": {
         "otmVersion": {
-            "type": "string",
+            "type": "string"
         },
         "project": {
             "type": "object",

--- a/otm_schema.json
+++ b/otm_schema.json
@@ -4,8 +4,11 @@
     "title": "Open Threat Model Specification",
     "$comment" : "Open Threat Model JSON schema is published under the terms of the Apache License 2.0.",
     "type": "object",
-    "required": ["project", "otmVersion"],
+    "required": ["otmVersion", "project"],
     "properties": {
+        "otmVersion": {
+            "type": "string",
+        },
         "project": {
             "type": "object",
             "required": ["name", "id"],

--- a/otm_schema.json
+++ b/otm_schema.json
@@ -123,7 +123,7 @@
                     },
                     "threats": {
                         "type": "array",
-                        "items": {"$ref": "#/definitions/threat/"}
+                        "items": {"$ref": "#/definitions/threat"}
                     },
                     "tags": {
                         "type": "array",


### PR DESCRIPTION
Schema from PR https://github.com/iriusrisk/OpenThreatModel/pull/15, that is a direct copy from https://github.com/iriusrisk/startleft/blob/main/otm/resources/schemas/otm_schema.json, does not validate correctly in some implementations and `otmVersion` was not specified in the schema as a property before. 

![image](https://github.com/iriusrisk/OpenThreatModel/assets/4015237/0250ff57-f196-4dcf-99fc-ddc18b3b5268)

![image](https://github.com/iriusrisk/OpenThreatModel/assets/4015237/09c82f46-2817-49ad-8c33-a5f1601cea24)

With these changes the schema validates correctly. 

https://www.liquid-technologies.com/online-json-schema-validator

https://jsonschemalint.com/#!/version/draft-07/markup/json