### PR TITLE
Adding optional representations to the dataflow type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a complete example see [EXAMPLE.yaml](EXAMPLE.yaml) or [EXAMPLE.json](EXAMPL
 The Open Threat Model specification is versioned using [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) (semver) and follows the semver specification.
 
 ```
-Current schema version: 0.1.0
+Current schema version: 0.1.1
 ```
 
 # Format

--- a/otm_schema.json
+++ b/otm_schema.json
@@ -134,6 +134,10 @@
                     "bidirectional": {"type": ["boolean", "null"]},
                     "source": {"type": "string"},
                     "destination": {"type": "string"},
+                    "representations": {
+                        "type": ["array", "null"],
+                        "items": {"$ref": "#/definitions/representationElement"}
+                    },
                     "assets": {
                         "type": ["array", "null"],
                         "items": {"type": ["string", "null"]}


### PR DESCRIPTION
I noticed in the example JSON files that there are `representations` in the `dataflow` elements. But this isn't defined in the schema. This PR adds this to the schema.

I don't know if this requires a minor version semantic bump, but I added that in too - but happy for you folks to manage the versioning how ever you feel is appropriate.

Thanks!