### PR TITLE
[feature/OPT-952] to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,122 @@
+# Workspace
+*.code-workspace
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+test-reports/
+/coveragereport/
+
+# SonarLint plugin
+.scannerwork
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# caret editor
+caret
+
+# IntelliJ/Pycharm folder
+/.idea
+
+# Intermediate files
+**/diagram.xml
+**/product.xml

--- a/EXAMPLE.json
+++ b/EXAMPLE.json
@@ -1,5 +1,5 @@
 {
-  "otmVersion": "0.1.0",
+  "otmVersion": "0.2.0",
   "project": {
     "name": "Test project",
     "id": "test-project",
@@ -229,6 +229,7 @@
     {
       "name": "Internet",
       "id": "f0ba7722-39b6-4c81-8290-a30a248bb8d9",
+      "type": "internet",
       "description": "This is the internet trust zone",
       "risk": {
         "trustRating": 20
@@ -252,6 +253,7 @@
     {
       "name": "Private",
       "id": "2ab4effa-40b7-4cd2-ba81-8247d29a6f2d",
+      "type": "private",
       "description": "Private trustzone for protected components",
       "risk": {
         "trustRating": 100

--- a/EXAMPLE.json
+++ b/EXAMPLE.json
@@ -229,7 +229,6 @@
     {
       "name": "Internet",
       "id": "f0ba7722-39b6-4c81-8290-a30a248bb8d9",
-      "type": "internet",
       "description": "This is the internet trust zone",
       "risk": {
         "trustRating": 20
@@ -253,7 +252,6 @@
     {
       "name": "Private",
       "id": "2ab4effa-40b7-4cd2-ba81-8247d29a6f2d",
-      "type": "private",
       "description": "Private trustzone for protected components",
       "risk": {
         "trustRating": 100

--- a/EXAMPLE.yaml
+++ b/EXAMPLE.yaml
@@ -1,4 +1,4 @@
-otmVersion: 0.1.0
+otmVersion: 0.2.0
 project:
   name: Test project
   id: test-project
@@ -167,6 +167,7 @@ dataflows:
 trustZones:
   - name: Internet
     id: f0ba7722-39b6-4c81-8290-a30a248bb8d9
+    type: internet
     description: This is the internet trust zone
     risk:
       trustRating: 20
@@ -182,6 +183,7 @@ trustZones:
     attributes:
   - name: Private
     id: 2ab4effa-40b7-4cd2-ba81-8247d29a6f2d
+    type: private
     description: Private trustzone for protected components
     risk:
       trustRating: 100

--- a/EXAMPLE.yaml
+++ b/EXAMPLE.yaml
@@ -167,7 +167,6 @@ dataflows:
 trustZones:
   - name: Internet
     id: f0ba7722-39b6-4c81-8290-a30a248bb8d9
-    type: internet
     description: This is the internet trust zone
     risk:
       trustRating: 20
@@ -183,7 +182,6 @@ trustZones:
     attributes:
   - name: Private
     id: 2ab4effa-40b7-4cd2-ba81-8247d29a6f2d
-    type: private
     description: Private trustzone for protected components
     risk:
       trustRating: 100

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a complete example see [EXAMPLE.yaml](EXAMPLE.yaml) or [EXAMPLE.json](EXAMPL
 The Open Threat Model specification is versioned using [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) (semver) and follows the semver specification.
 
 ```
-Current schema version: 0.1.0
+Current schema version: 0.2.0
 ```
 
 # Format
@@ -1128,6 +1128,18 @@ Trust zones are the different areas within which components are located. They de
 <td>
 
     id: 730df42e-69a4-11ed-bd69-9b318e4f98c5
+
+</td>
+</tr>
+
+<tr></tr>
+<tr>
+<td>type</td>
+<td>string</td>
+<td><b>RECOMMENDED (required in the next major version)</b> Type for the trust zone</td>
+<td>
+
+    type: internet
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ Assets are the different kinds of sensible information that take part in our thr
 
 ```yaml
 assets:
-    - name: Credit Card Data
+  - name: Credit Card Data
     id: cc-data
     description: Credit card numbers used for payments in the platform
     risk:
@@ -1134,18 +1134,6 @@ Trust zones are the different areas within which components are located. They de
 
 <tr></tr>
 <tr>
-<td>type</td>
-<td>string</td>
-<td><b>REQUIRED</b> Type for the trust zone</td>
-<td>
-
-    type: internet
-
-</td>
-</tr>
-
-<tr></tr>
-<tr>
 <td>description</td>
 <td>richText</td>
 <td>Short description for the trust zone</td>
@@ -1211,7 +1199,6 @@ A trust zone can have <b>zero or one parent</b>: another component or a trust zo
 trustzones:
   - name: Internet
     id: 730df42e-69a4-11ed-bd69-9b318e4f98c5
-    type: internet
     description: This is the internet trust zone
     risk:
       trustRating: 20
@@ -1864,7 +1851,7 @@ mitigations:
   - name: Mitigation 2
     id: 3b837730-e300-11eb-ba80-0242ac130004
     description: Description for mitigation 2
-    riskReduction 100
+    riskReduction: 100
 ```
 
 ## Mitigation instance object

--- a/otm_schema.json
+++ b/otm_schema.json
@@ -74,7 +74,6 @@
                 "properties": {
                     "id": {"type": "string"},
                     "name": {"type": "string"},
-                    "type": {"type": "string"},
                     "description": {"type": ["string", "null"]},
                     "risk": {
                         "type": "object",

--- a/otm_schema.json
+++ b/otm_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://iriusrisk.com/schema/otm-0.1.0.schema.json",
+    "$id": "https://iriusrisk.com/schema/otm-0.2.0.schema.json",
     "title": "Open Threat Model Specification",
     "$comment" : "Open Threat Model JSON schema is published under the terms of the Apache License 2.0.",
     "type": "object",
@@ -74,6 +74,7 @@
                 "properties": {
                     "id": {"type": "string"},
                     "name": {"type": "string"},
+                    "type": {"type": "string"},
                     "description": {"type": ["string", "null"]},
                     "risk": {
                         "type": "object",


### PR DESCRIPTION
Versions 0.1.0 and 0.2.0 regularized:
- TrustZone object in v0.1.0 does not contain a type field.
- TrustZone object in v0.2.0 contains a recommended (not required) type field.