### PR TITLE
define objects for all arrays

### DIFF
--- a/otm_schema.json
+++ b/otm_schema.json
@@ -29,41 +29,47 @@
         },
         "representations": {
             "type": ["array", "null"],
-            "required": ["name", "id", "type"],
-            "properties": {
-                "name": {"type": "string"},
-                "id": {"type": "string"},
-                "type": {"type": "string"},
-                "description": {"type": ["string", "null"]},
-                "size": {"$ref": "#/definitions/size"},
-                "repository": {
-                    "type": ["object", "null"],
-                    "required": ["url"],
-                    "properties": {
-                        "url": {"type": ["string", "null"]}
-                    }
-                },
-                "attributes": {"type": ["object", "null"]}
+            "items": {
+                "type": "object",
+                "required": ["name", "id", "type"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "id": {"type": "string"},
+                    "type": {"type": "string"},
+                    "description": {"type": ["string", "null"]},
+                    "size": {"$ref": "#/definitions/size"},
+                    "repository": {
+                        "type": ["object", "null"],
+                        "required": ["url"],
+                        "properties": {
+                            "url": {"type": ["string", "null"]}
+                        }
+                    },
+                    "attributes": {"type": ["object", "null"]}
+                }
             }
         },
         "assets": {
             "type": ["array", "null"],
-            "required": ["name", "id", "risk"],
-            "properties": {
-                "name": {"type": "string"},
-                "id": {"type": "string"},
-                "description": {"type": ["string", "null"]},
-                "risk": {
-                    "type": "object",
-                    "required": ["confidentiality", "integrity", "availability"],
-                    "properties": {
-                        "confidentiality": {"type": "number"},
-                        "integrity": {"type": "number"},
-                        "availability": {"type": "number"},
-                        "comment": {"type": ["string", "null"]}
-                    }
-                },
-                "attributes": {"type": ["object", "null"]}
+            "items": {
+                "type": "object",
+                "required": ["name", "id", "risk"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "id": {"type": "string"},
+                    "description": {"type": ["string", "null"]},
+                    "risk": {
+                        "type": "object",
+                        "required": ["confidentiality", "integrity", "availability"],
+                        "properties": {
+                            "confidentiality": {"type": "number"},
+                            "integrity": {"type": "number"},
+                            "availability": {"type": "number"},
+                            "comment": {"type": ["string", "null"]}
+                        }
+                    },
+                    "attributes": {"type": ["object", "null"]}
+                }
             }
         },
         "trustZones": {


### PR DESCRIPTION
This pull request defines the arrays 'representations' and 'assets' as arrays of objects, rather than arrays. This allows for strict compiling of the schema without warnings

Closes #23 