### PR TITLE
added "package" property to the "representationElement"

### DIFF
--- a/otm_schema.json
+++ b/otm_schema.json
@@ -248,6 +248,7 @@
                 "position": {"$ref": "#/definitions/position"},
                 "size": {"$ref": "#/definitions/size"},
                 "file": {"type": ["string", "null"]},
+                "package": {"type": ["string", "null"]},
                 "line": {"type": ["number", "null"]},
                 "codeSnippet": {"type": ["string", "null"]},
                 "attributes": {"type": ["object", "null"]}


### PR DESCRIPTION
I've noticed in EXAMPLE.json there is examples of `package` elements in `representation` elements. This addresses that, as filed as issue: https://github.com/iriusrisk/OpenThreatModel/issues/28